### PR TITLE
feat: Add Filament commands for modular structure

### DIFF
--- a/src/Commands/Aliases/MakeModularPageCommand.php
+++ b/src/Commands/Aliases/MakeModularPageCommand.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace RealMrHex\FilamentModularV3\Commands\Aliases;
+
+use Filament\Commands;
+
+class MakeModularPageCommand extends Commands\MakePageCommand
+{
+    protected $hidden = true;
+
+    protected $signature = 'filament-module:page {module?} {name?} {--R|resource=} {--T|type=} {--panel=} {--F|force}';
+}

--- a/src/Commands/Aliases/MakeModularRelationManagerCommand.php
+++ b/src/Commands/Aliases/MakeModularRelationManagerCommand.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace RealMrHex\FilamentModularV3\Commands\Aliases;
+
+use Filament\Commands;
+
+class MakeModularRelationManagerCommand extends Commands\MakeRelationManagerCommand
+{
+    protected $hidden = true;
+
+    protected $signature = 'filament-module:relation-manager {module?} {resource?} {relationship?} {recordTitleAttribute?} {--attach} {--associate} {--soft-deletes} {--view} {--panel=} {--F|force}';
+}

--- a/src/Commands/Aliases/MakeModularResourceCommand.php
+++ b/src/Commands/Aliases/MakeModularResourceCommand.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace RealMrHex\FilamentModularV3\Commands\Aliases;
+
+use Filament\Commands;
+
+class MakeModularResourceCommand extends Commands\MakeResourceCommand
+{
+    protected $hidden = true;
+
+    protected $signature = 'filament-module:resource {module?} {name?} {--soft-deletes} {--view} {--G|generate} {--S|simple} {--panel=} {--F|force}';
+}

--- a/src/Commands/Aliases/MakePanelCommand.php
+++ b/src/Commands/Aliases/MakePanelCommand.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace RealMrHex\FilamentModularV3\Commands\Aliases;
+
+use Filament\Commands;
+
+class MakePanelCommand extends Commands\MakePanelCommand
+{
+    protected $hidden = true;
+
+    protected $signature = 'filament-module:panel {module?} {id?} {--F|force}';
+}

--- a/src/Commands/MakeModularPageCommand.php
+++ b/src/Commands/MakeModularPageCommand.php
@@ -1,0 +1,216 @@
+<?php
+
+namespace RealMrHex\FilamentModularV3\Commands;
+
+use Filament\Facades\Filament;
+use Filament\Panel;
+use Filament\Support\Commands\Concerns\CanManipulateFiles;
+use Illuminate\Console\Command;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+
+use function Laravel\Prompts\select;
+use function Laravel\Prompts\text;
+
+class MakeModularPageCommand extends Command
+{
+    use CanManipulateFiles;
+
+    protected $description = 'Create a new Filament page class and view';
+
+    protected $signature = 'filament-module:page {module?} {name?} {--R|resource=} {--T|type=} {--panel=} {--F|force}';
+
+    public function handle(): int
+    {
+
+        $module_name = $this->argument('module') ?? text(
+            label: 'What is the module name?',
+            placeholder: 'User',
+            required: true,
+        );
+        $module_name = Str::of($module_name)->studly()->toString();
+        $module = null;
+        $moduleNamespace = null;
+        try {
+            $module = app('modules')->findOrFail($module_name);
+        } catch (Throwable $exception) {
+            $this->error('module not found');
+
+            return static::INVALID;
+        }
+
+        $page = (string) str(
+            $this->argument('name') ??
+            text(
+                label: 'What is the page name?',
+                placeholder: 'EditSettings',
+                required: true,
+            ),
+        )
+            ->trim('/')
+            ->trim('\\')
+            ->trim(' ')
+            ->replace('/', '\\');
+        $pageClass = (string) str($page)->afterLast('\\');
+        $pageNamespace = str($page)->contains('\\') ?
+            (string) str($page)->beforeLast('\\') :
+            '';
+
+        $resource = null;
+        $resourceClass = null;
+        $resourcePage = null;
+
+        $resourceInput = $this->option('resource') ?? text(
+            label: 'Would you like to create the page inside a resource?',
+            placeholder: '[Optional] UserResource',
+        );
+
+        if (filled($resourceInput)) {
+            $resource = (string) str($resourceInput)
+                ->studly()
+                ->trim('/')
+                ->trim('\\')
+                ->trim(' ')
+                ->replace('/', '\\');
+
+            if (! str($resource)->endsWith('Resource')) {
+                $resource .= 'Resource';
+            }
+
+            $resourceClass = (string) str($resource)
+                ->afterLast('\\');
+
+            $resourcePage = $this->option('type') ?? select(
+                label: 'Which type of page would you like to create?',
+                options: [
+                    'custom' => 'Custom',
+                    'ListRecords' => 'List',
+                    'CreateRecord' => 'Create',
+                    'EditRecord' => 'Edit',
+                    'ViewRecord' => 'View',
+                    'ManageRecords' => 'Manage',
+                ],
+                default: 'custom'
+            );
+        }
+
+        $panel = $this->option('panel');
+
+        if ($panel) {
+            $panel = Filament::getPanel($panel);
+        }
+
+        if (! $panel) {
+            $panels = Filament::getPanels();
+
+            /** @var Panel $panel */
+            $panel = (count($panels) > 1) ? $panels[select(
+                label: 'Which panel would you like to create this in?',
+                options: array_map(
+                    fn (Panel $panel): string => $panel->getId(),
+                    $panels,
+                ),
+                default: Filament::getDefaultPanel()->getId()
+            )] : Arr::first($panels);
+        }
+
+        $panelId = (string) str($panel->getId())->studly();
+
+        if (empty($resource)) {
+            $pageDirectories = $panel->getPageDirectories();
+            $pageNamespaces = $panel->getPageNamespaces();
+
+            $pageModuleDirectory = $module->getPath()."/Filament/{$panelId}/Pages/";
+            $moduleNamespace = config('modules.namespace')."\\{$module->getName()}\Filament\\{$panelId}\Pages";
+
+            $namespace = (count($pageNamespaces) > 1) ?
+                select(
+                    label: 'Which namespace would you like to create this in?',
+                    options: $pageNamespaces
+                ) :
+                (Arr::first($pageNamespaces) ?? $moduleNamespace);
+            $path = (count($pageDirectories) > 1) ?
+                $pageDirectories[array_search($namespace, $pageNamespaces)] :
+                (Arr::first($pageDirectories) ?? $pageModuleDirectory);
+        } else {
+            $resourceDirectories = $panel->getResourceDirectories();
+            $resourceNamespaces = $panel->getResourceNamespaces();
+
+            $resourceModuleDirectory = $module->getPath()."/Filament/{$panelId}/Resources/";
+            $moduleNamespace = config('modules.namespace')."\\{$module->getName()}\Filament\\{$panelId}\Resources";
+
+            $resourceNamespace = (count($resourceNamespaces) > 1) ?
+                select(
+                    label: 'Which namespace would you like to create this in?',
+                    options: $resourceNamespaces
+                ) :
+                (Arr::first($resourceNamespaces) ?? $moduleNamespace);
+            $resourcePath = (count($resourceDirectories) > 1) ?
+                $resourceDirectories[array_search($resourceNamespace, $resourceNamespaces)] :
+                (Arr::first($resourceDirectories) ?? $resourceModuleDirectory);
+        }
+
+        $view = str($page)
+            ->prepend(
+                (string) str(empty($resource) ? "{$namespace}\\" : "{$resourceNamespace}\\{$resource}\\pages\\")
+                    ->replaceFirst('App\\', '')
+            )
+            ->replace('\\', '/')
+            ->explode('/')
+            ->map(fn ($segment) => Str::lower(Str::kebab($segment)))
+            ->implode('.');
+
+        $path = (string) str($page)
+            ->prepend('/')
+            ->prepend(empty($resource) ? ($path ?? '') : ($resourcePath ?? '')."\\{$resource}\\Pages\\")
+            ->replace('\\', '/')
+            ->replace('//', '/')
+            ->append('.php');
+
+        $viewPath = resource_path(
+            (string) str($view)
+                ->replace('.', '/')
+                ->prepend('views/')
+                ->append('.blade.php'),
+        );
+
+        $files = [
+            $path,
+            ...($resourcePage === 'custom' ? [$viewPath] : []),
+        ];
+
+        if (! $this->option('force') && $this->checkForCollision($files)) {
+            return static::INVALID;
+        }
+
+        if (empty($resource)) {
+            $this->copyStubToApp('Page', $path, [
+                'class' => $pageClass,
+                'namespace' => str($namespace ?? '').($pageNamespace !== '' ? "\\{$pageNamespace}" : ''),
+                'view' => $view,
+            ]);
+        } else {
+            $this->copyStubToApp($resourcePage === 'custom' ? 'CustomResourcePage' : 'ResourcePage', $path, [
+                'baseResourcePage' => 'Filament\\Resources\\Pages\\'.($resourcePage === 'custom' ? 'Page' : $resourcePage),
+                'baseResourcePageClass' => $resourcePage === 'custom' ? 'Page' : $resourcePage,
+                'namespace' => ($resourceNamespace ?? '')."\\{$resource}\\Pages".($pageNamespace !== '' ? "\\{$pageNamespace}" : ''),
+                'resource' => ($resourceNamespace ?? '')."\\{$resource}",
+                'resourceClass' => $resourceClass,
+                'resourcePageClass' => $pageClass,
+                'view' => $view,
+            ]);
+        }
+
+        if (empty($resource) || $resourcePage === 'custom') {
+            $this->copyStubToApp('PageView', $viewPath);
+        }
+
+        $this->components->info("Successfully created {$page}!");
+
+        if ($resource !== null) {
+            $this->components->info("Make sure to register the page in `{$resourceClass}::getPages()`.");
+        }
+
+        return static::SUCCESS;
+    }
+}

--- a/src/Commands/MakeModularRelationManagerCommand.php
+++ b/src/Commands/MakeModularRelationManagerCommand.php
@@ -1,0 +1,214 @@
+<?php
+
+namespace RealMrHex\FilamentModularV3\Commands;
+
+use Filament\Facades\Filament;
+use Filament\Panel;
+use Filament\Support\Commands\Concerns\CanIndentStrings;
+use Filament\Support\Commands\Concerns\CanManipulateFiles;
+use Illuminate\Console\Command;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+
+use function Laravel\Prompts\select;
+use function Laravel\Prompts\text;
+
+class MakeModularRelationManagerCommand extends Command
+{
+    use CanIndentStrings;
+    use CanManipulateFiles;
+
+    protected $description = 'Create a new Filament relation manager class for a resource';
+
+    protected $signature = 'filament-module:relation-manager {module?} {resource?} {relationship?} {recordTitleAttribute?} {--attach} {--associate} {--soft-deletes} {--view} {--panel=} {--F|force}';
+
+    public function handle(): int
+    {
+
+        $module_name = $this->argument('module') ?? text(
+            label: 'What is the module name?',
+            placeholder: 'User',
+            required: true,
+        );
+        $module_name = Str::of($module_name)->studly()->toString();
+        $module = null;
+        $moduleNamespace = null;
+        try {
+            $module = app('modules')->findOrFail($module_name);
+        } catch (Throwable $exception) {
+            $this->error('module not found');
+
+            return static::INVALID;
+        }
+
+        $resource = (string) str(
+            $this->argument('resource') ?? text(
+                label: 'What is the resource you would like to create this in?',
+                placeholder: 'DepartmentResource',
+                required: true,
+            ),
+        )
+            ->studly()
+            ->trim('/')
+            ->trim('\\')
+            ->trim(' ')
+            ->replace('/', '\\');
+
+        if (! str($resource)->endsWith('Resource')) {
+            $resource .= 'Resource';
+        }
+
+        $relationship = (string) str($this->argument('relationship') ?? text(
+            label: 'What is the relationship?',
+            placeholder: 'members',
+            required: true,
+        ))
+            ->trim(' ');
+        $managerClass = (string) str($relationship)
+            ->studly()
+            ->append('RelationManager');
+
+        $recordTitleAttribute = (string) str($this->argument('recordTitleAttribute') ?? text(
+            label: 'What is the title attribute?',
+            placeholder: 'name',
+            required: true,
+        ))
+            ->trim(' ');
+
+        $panel = $this->option('panel');
+
+        if ($panel) {
+            $panel = Filament::getPanel($panel);
+        }
+
+        if (! $panel) {
+            $panels = Filament::getPanels();
+
+            /** @var Panel $panel */
+            $panel = (count($panels) > 1) ? $panels[select(
+                label: 'Which panel would you like to create this in?',
+                options: array_map(
+                    fn (Panel $panel): string => $panel->getId(),
+                    $panels,
+                ),
+                default: Filament::getDefaultPanel()->getId()
+            )] : Arr::first($panels);
+        }
+
+        $panelId = (string) str($panel->getId())->studly();
+
+        $resourceDirectories = $panel->getResourceDirectories();
+        $resourceNamespaces = $panel->getResourceNamespaces();
+
+        $resourceModuleDirectory = $module->getPath()."/Filament/{$panelId}/Resources/";
+        $moduleNamespace = config('modules.namespace')."\\{$module->getName()}\Filament\\{$panelId}\Resources";
+
+        $resourceNamespace = (count($resourceNamespaces) > 1) ?
+            select(
+                label: 'Which namespace would you like to create this in?',
+                options: $resourceNamespaces
+            ) :
+            (Arr::first($resourceNamespaces) ?? $moduleNamespace);
+        $resourcePath = (count($resourceDirectories) > 1) ?
+            $resourceDirectories[array_search($resourceNamespace, $resourceNamespaces)] :
+            (Arr::first($resourceDirectories) ?? $resourceModuleDirectory);
+
+        $path = (string) str($managerClass)
+            ->prepend("{$resourcePath}/{$resource}/RelationManagers/")
+            ->replace('\\', '/')
+            ->replace(app_path(), $module->getPath())
+            ->append('.php');
+
+        if (! $this->option('force') && $this->checkForCollision([
+            $path,
+        ])) {
+            return static::INVALID;
+        }
+
+        $tableHeaderAndEmptyStateActions = [];
+
+        $tableHeaderAndEmptyStateActions[] = 'Tables\Actions\CreateAction::make(),';
+
+        if ($this->option('associate')) {
+            $tableHeaderAndEmptyStateActions[] = 'Tables\Actions\AssociateAction::make(),';
+        }
+
+        if ($this->option('attach')) {
+            $tableHeaderAndEmptyStateActions[] = 'Tables\Actions\AttachAction::make(),';
+        }
+
+        $tableHeaderAndEmptyStateActions = implode(PHP_EOL, $tableHeaderAndEmptyStateActions);
+
+        $tableActions = [];
+
+        if ($this->option('view')) {
+            $tableActions[] = 'Tables\Actions\ViewAction::make(),';
+        }
+
+        $tableActions[] = 'Tables\Actions\EditAction::make(),';
+
+        if ($this->option('associate')) {
+            $tableActions[] = 'Tables\Actions\DissociateAction::make(),';
+        }
+
+        if ($this->option('attach')) {
+            $tableActions[] = 'Tables\Actions\DetachAction::make(),';
+        }
+
+        $tableActions[] = 'Tables\Actions\DeleteAction::make(),';
+
+        if ($this->option('soft-deletes')) {
+            $tableActions[] = 'Tables\Actions\ForceDeleteAction::make(),';
+            $tableActions[] = 'Tables\Actions\RestoreAction::make(),';
+        }
+
+        $tableActions = implode(PHP_EOL, $tableActions);
+
+        $tableBulkActions = [];
+
+        if ($this->option('associate')) {
+            $tableBulkActions[] = 'Tables\Actions\DissociateBulkAction::make(),';
+        }
+
+        if ($this->option('attach')) {
+            $tableBulkActions[] = 'Tables\Actions\DetachBulkAction::make(),';
+        }
+
+        $tableBulkActions[] = 'Tables\Actions\DeleteBulkAction::make(),';
+
+        $modifyQueryUsing = '';
+
+        if ($this->option('soft-deletes')) {
+            $modifyQueryUsing .= '->modifyQueryUsing(fn (Builder $query) => $query->withoutGlobalScopes([';
+            $modifyQueryUsing .= PHP_EOL.'    SoftDeletingScope::class,';
+            $modifyQueryUsing .= PHP_EOL.']))';
+
+            $tableBulkActions[] = 'Tables\Actions\RestoreBulkAction::make(),';
+            $tableBulkActions[] = 'Tables\Actions\ForceDeleteBulkAction::make(),';
+        }
+
+        $tableBulkActions = implode(PHP_EOL, $tableBulkActions);
+
+        $this->copyStubToApp('RelationManager', $path, [
+            'modifyQueryUsing' => filled($modifyQueryUsing) ? PHP_EOL.$this->indentString($modifyQueryUsing, 3) : $modifyQueryUsing,
+            'namespace' => "{$resourceNamespace}\\{$resource}\\RelationManagers",
+            'managerClass' => $managerClass,
+            'recordTitleAttribute' => $recordTitleAttribute,
+            'relationship' => $relationship,
+            'tableActions' => $this->indentString($tableActions, 4),
+            'tableBulkActions' => $this->indentString($tableBulkActions, 5),
+            'tableEmptyStateActions' => $this->indentString($tableHeaderAndEmptyStateActions, 4),
+            'tableFilters' => $this->indentString(
+                $this->option('soft-deletes') ? 'Tables\Filters\TrashedFilter::make()' : '//',
+                4,
+            ),
+            'tableHeaderActions' => $this->indentString($tableHeaderAndEmptyStateActions, 4),
+        ]);
+
+        $this->components->info("Successfully created {$managerClass}!");
+
+        $this->components->info("Make sure to register the relation in `{$resource}::getRelations()`.");
+
+        return static::SUCCESS;
+    }
+}

--- a/src/Commands/MakeModularResourceCommand.php
+++ b/src/Commands/MakeModularResourceCommand.php
@@ -1,0 +1,301 @@
+<?php
+
+namespace RealMrHex\FilamentModularV3\Commands;
+
+use Filament\Facades\Filament;
+use Filament\Forms\Commands\Concerns\CanGenerateForms;
+use Filament\Panel;
+use Filament\Support\Commands\Concerns\CanIndentStrings;
+use Filament\Support\Commands\Concerns\CanManipulateFiles;
+use Filament\Support\Commands\Concerns\CanReadModelSchemas;
+use Filament\Tables\Commands\Concerns\CanGenerateTables;
+use Illuminate\Console\Command;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+use Throwable;
+
+use function Laravel\Prompts\select;
+use function Laravel\Prompts\text;
+
+class MakeModularResourceCommand extends Command
+{
+    use CanGenerateForms;
+    use CanGenerateTables;
+    use CanIndentStrings;
+    use CanManipulateFiles;
+    use CanReadModelSchemas;
+
+    protected $description = 'Create a new Filament resource class and default page classes';
+
+    protected $signature = 'filament-module:resource {module?} {name?} {--soft-deletes} {--view} {--G|generate} {--S|simple} {--panel=} {--F|force}';
+
+    public function handle(): int
+    {
+
+        $module_name = $this->argument('module') ?? text(
+            label: 'What is the module name?',
+            placeholder: 'User',
+            required: true,
+        );
+        $module_name = Str::of($module_name)->studly()->toString();
+        $module = null;
+        $moduleNamespace = null;
+        try {
+            $module = app('modules')->findOrFail($module_name);
+        } catch (Throwable $exception) {
+            $this->error('module not found');
+
+            return static::INVALID;
+        }
+
+        $model = (string) str($this->argument('name') ?? text(
+            label: 'What is the model name?',
+            placeholder: 'BlogPost',
+            required: true,
+        ))
+            ->studly()
+            ->beforeLast('Resource')
+            ->trim('/')
+            ->trim('\\')
+            ->trim(' ')
+            ->studly()
+            ->replace('/', '\\');
+
+        if (blank($model)) {
+            $model = 'Resource';
+        }
+
+        $modelClass = (string) str($model)->afterLast('\\');
+        $modelNamespace = str($model)->contains('\\') ?
+            (string) str($model)->beforeLast('\\') :
+            '';
+        $pluralModelClass = (string) str($modelClass)->pluralStudly();
+
+        $panel = $this->option('panel');
+
+        if ($panel) {
+            $panel = Filament::getPanel($panel);
+        }
+
+        if (! $panel) {
+            $panels = Filament::getPanels();
+
+            /** @var Panel $panel */
+            $panel = (count($panels) > 1) ? $panels[select(
+                label: 'Which panel would you like to create this in?',
+                options: array_map(
+                    fn (Panel $panel): string => $panel->getId(),
+                    $panels,
+                ),
+                default: Filament::getDefaultPanel()->getId()
+            )] : Arr::first($panels);
+        }
+
+        $resourceDirectories = $panel->getResourceDirectories();
+        $resourceNamespaces = $panel->getResourceNamespaces();
+
+        $panelId = (string) str($panel->getId())->studly();
+
+        $resourceModuleDirectory = $module->getPath()."/Filament/{$panelId}/Resources/";
+        $moduleNamespace = config('modules.namespace')."\\{$module->getName()}\Filament\\{$panelId}\Resources";
+
+        $namespace = (count($resourceNamespaces) > 1) ?
+            select(
+                label: 'Which namespace would you like to create this in?',
+                options: $resourceNamespaces
+            ) :
+            (Arr::first($resourceNamespaces) ?? $module->getPath());
+        $path = (count($resourceDirectories) > 1) ?
+            $resourceDirectories[array_search($namespace, $resourceNamespaces)] :
+            (Arr::first($resourceDirectories) ?? $resourceModuleDirectory);
+
+        $resource = "{$model}Resource";
+        $resourceClass = "{$modelClass}Resource";
+        $resourceNamespace = $modelNamespace;
+        $namespace .= $resourceNamespace !== '' ? "\\{$resourceNamespace}" : '';
+        $namespace = $moduleNamespace;
+        $listResourcePageClass = "List{$pluralModelClass}";
+        $manageResourcePageClass = "Manage{$pluralModelClass}";
+        $createResourcePageClass = "Create{$modelClass}";
+        $editResourcePageClass = "Edit{$modelClass}";
+        $viewResourcePageClass = "View{$modelClass}";
+
+        $baseResourcePath =
+            (string) str($resource)
+                ->prepend('/')
+                ->prepend($path)
+                ->replace('\\', '/')
+                ->replace('//', '/')
+                ->replace(app_path(), $module->getPath());
+
+        $resourcePath = "{$baseResourcePath}.php";
+        $resourcePagesDirectory = "{$baseResourcePath}/Pages";
+        $listResourcePagePath = "{$resourcePagesDirectory}/{$listResourcePageClass}.php";
+        $manageResourcePagePath = "{$resourcePagesDirectory}/{$manageResourcePageClass}.php";
+        $createResourcePagePath = "{$resourcePagesDirectory}/{$createResourcePageClass}.php";
+        $editResourcePagePath = "{$resourcePagesDirectory}/{$editResourcePageClass}.php";
+        $viewResourcePagePath = "{$resourcePagesDirectory}/{$viewResourcePageClass}.php";
+
+        if (! $this->option('force') && $this->checkForCollision([
+            $resourcePath,
+            $listResourcePagePath,
+            $manageResourcePagePath,
+            $createResourcePagePath,
+            $editResourcePagePath,
+            $viewResourcePagePath,
+        ])) {
+            return static::INVALID;
+        }
+
+        $pages = '';
+        $pages .= '\'index\' => Pages\\'.($this->option('simple') ? $manageResourcePageClass : $listResourcePageClass).'::route(\'/\'),';
+
+        if (! $this->option('simple')) {
+            $pages .= PHP_EOL."'create' => Pages\\{$createResourcePageClass}::route('/create'),";
+
+            if ($this->option('view')) {
+                $pages .= PHP_EOL."'view' => Pages\\{$viewResourcePageClass}::route('/{record}'),";
+            }
+
+            $pages .= PHP_EOL."'edit' => Pages\\{$editResourcePageClass}::route('/{record}/edit'),";
+        }
+
+        $tableActions = [];
+
+        if ($this->option('view')) {
+            $tableActions[] = 'Tables\Actions\ViewAction::make(),';
+        }
+
+        $tableActions[] = 'Tables\Actions\EditAction::make(),';
+
+        $relations = '';
+
+        if ($this->option('simple')) {
+            $tableActions[] = 'Tables\Actions\DeleteAction::make(),';
+
+            if ($this->option('soft-deletes')) {
+                $tableActions[] = 'Tables\Actions\ForceDeleteAction::make(),';
+                $tableActions[] = 'Tables\Actions\RestoreAction::make(),';
+            }
+        } else {
+            $relations .= PHP_EOL.'public static function getRelations(): array';
+            $relations .= PHP_EOL.'{';
+            $relations .= PHP_EOL.'    return [';
+            $relations .= PHP_EOL.'        //';
+            $relations .= PHP_EOL.'    ];';
+            $relations .= PHP_EOL.'}'.PHP_EOL;
+        }
+
+        $tableActions = implode(PHP_EOL, $tableActions);
+
+        $tableEmptyStateActions = [];
+
+        $tableEmptyStateActions[] = 'Tables\Actions\CreateAction::make(),';
+
+        $tableEmptyStateActions = implode(PHP_EOL, $tableEmptyStateActions);
+
+        $tableBulkActions = [];
+
+        $tableBulkActions[] = 'Tables\Actions\DeleteBulkAction::make(),';
+
+        $eloquentQuery = '';
+
+        if ($this->option('soft-deletes')) {
+            $tableBulkActions[] = 'Tables\Actions\ForceDeleteBulkAction::make(),';
+            $tableBulkActions[] = 'Tables\Actions\RestoreBulkAction::make(),';
+
+            $eloquentQuery .= PHP_EOL.PHP_EOL.'public static function getEloquentQuery(): Builder';
+            $eloquentQuery .= PHP_EOL.'{';
+            $eloquentQuery .= PHP_EOL.'    return parent::getEloquentQuery()';
+            $eloquentQuery .= PHP_EOL.'        ->withoutGlobalScopes([';
+            $eloquentQuery .= PHP_EOL.'            SoftDeletingScope::class,';
+            $eloquentQuery .= PHP_EOL.'        ]);';
+            $eloquentQuery .= PHP_EOL.'}';
+        }
+
+        $tableBulkActions = implode(PHP_EOL, $tableBulkActions);
+
+        $this->copyStubToApp('Resource', $resourcePath, [
+            'eloquentQuery' => $this->indentString($eloquentQuery, 1),
+            'formSchema' => $this->indentString($this->option('generate') ? $this->getResourceFormSchema(
+                'App\\Models'.($modelNamespace !== '' ? "\\{$modelNamespace}" : '').'\\'.$modelClass,
+            ) : '//', 4),
+            'model' => $model === 'Resource' ? 'Resource as ResourceModel' : $model,
+            'modelClass' => $model === 'Resource' ? 'ResourceModel' : $modelClass,
+            'namespace' => $namespace,
+            'pages' => $this->indentString($pages, 3),
+            'relations' => $this->indentString($relations, 1),
+            'resource' => "{$namespace}\\{$resourceClass}",
+            'resourceClass' => $resourceClass,
+            'tableActions' => $this->indentString($tableActions, 4),
+            'tableBulkActions' => $this->indentString($tableBulkActions, 5),
+            'tableEmptyStateActions' => $this->indentString($tableEmptyStateActions, 4),
+            'tableColumns' => $this->indentString($this->option('generate') ? $this->getResourceTableColumns(
+                'App\Models'.($modelNamespace !== '' ? "\\{$modelNamespace}" : '').'\\'.$modelClass,
+            ) : '//', 4),
+            'tableFilters' => $this->indentString(
+                $this->option('soft-deletes') ? 'Tables\Filters\TrashedFilter::make(),' : '//',
+                4,
+            ),
+        ]);
+
+        if ($this->option('simple')) {
+            $this->copyStubToApp('ResourceManagePage', $manageResourcePagePath, [
+                'namespace' => "{$namespace}\\{$resourceClass}\\Pages",
+                'resource' => "{$namespace}\\{$resourceClass}",
+                'resourceClass' => $resourceClass,
+                'resourcePageClass' => $manageResourcePageClass,
+            ]);
+        } else {
+            $this->copyStubToApp('ResourceListPage', $listResourcePagePath, [
+                'namespace' => "{$namespace}\\{$resourceClass}\\Pages",
+                'resource' => "{$namespace}\\{$resourceClass}",
+                'resourceClass' => $resourceClass,
+                'resourcePageClass' => $listResourcePageClass,
+            ]);
+
+            $this->copyStubToApp('ResourcePage', $createResourcePagePath, [
+                'baseResourcePage' => 'Filament\\Resources\\Pages\\CreateRecord',
+                'baseResourcePageClass' => 'CreateRecord',
+                'namespace' => "{$namespace}\\{$resourceClass}\\Pages",
+                'resource' => "{$namespace}\\{$resourceClass}",
+                'resourceClass' => $resourceClass,
+                'resourcePageClass' => $createResourcePageClass,
+            ]);
+
+            $editPageActions = [];
+
+            if ($this->option('view')) {
+                $this->copyStubToApp('ResourceViewPage', $viewResourcePagePath, [
+                    'namespace' => "{$namespace}\\{$resourceClass}\\Pages",
+                    'resource' => "{$namespace}\\{$resourceClass}",
+                    'resourceClass' => $resourceClass,
+                    'resourcePageClass' => $viewResourcePageClass,
+                ]);
+
+                $editPageActions[] = 'Actions\ViewAction::make(),';
+            }
+
+            $editPageActions[] = 'Actions\DeleteAction::make(),';
+
+            if ($this->option('soft-deletes')) {
+                $editPageActions[] = 'Actions\ForceDeleteAction::make(),';
+                $editPageActions[] = 'Actions\RestoreAction::make(),';
+            }
+
+            $editPageActions = implode(PHP_EOL, $editPageActions);
+
+            $this->copyStubToApp('ResourceEditPage', $editResourcePagePath, [
+                'actions' => $this->indentString($editPageActions, 3),
+                'namespace' => "{$namespace}\\{$resourceClass}\\Pages",
+                'resource' => "{$namespace}\\{$resourceClass}",
+                'resourceClass' => $resourceClass,
+                'resourcePageClass' => $editResourcePageClass,
+            ]);
+        }
+
+        $this->components->info("Successfully created {$resource}!");
+
+        return static::SUCCESS;
+    }
+}

--- a/src/Commands/MakePanelCommand.php
+++ b/src/Commands/MakePanelCommand.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace RealMrHex\FilamentModularV3\Commands;
+
+use Filament\Support\Commands\Concerns\CanManipulateFiles;
+use Illuminate\Console\Command;
+use Illuminate\Support\Str;
+
+use function Laravel\Prompts\text;
+
+class MakePanelCommand extends Command
+{
+    use CanManipulateFiles;
+
+    protected $description = 'Create a new Filament panel';
+
+    protected $signature = 'filament-module:panel {module?} {id?} {--F|force}';
+
+    public function handle(): int
+    {
+
+        $module_name = $this->argument('module') ?? text(
+            label: 'What is the module name?',
+            placeholder: 'User',
+            required: true,
+        );
+
+        $module_name = Str::of($module_name)->studly()->toString();
+        $module = null;
+        $moduleNamespace = null;
+        try {
+            $module = app('modules')->findOrFail($module_name);
+            $moduleNamespace = config('modules.namespace')."\\{$module->getName()}\Providers\Filament\Panels";
+        } catch (Throwable $exception) {
+            $this->error('module not found');
+
+            return static::INVALID;
+        }
+
+        $id = Str::lcfirst($this->argument('id') ?? text(
+            label: 'What is the ID?',
+            placeholder: 'app',
+            required: true,
+        ));
+
+        $class = (string) str($id)
+            ->studly()
+            ->append('PanelProvider');
+
+        $path = (string) str($class)
+            ->prepend("{$module->getPath()}/Providers/Filament/Panels/")
+            ->replace('\\', '/')
+            ->append('.php');
+
+        if (! $this->option('force') && $this->checkForCollision([$path])) {
+            return static::INVALID;
+        }
+
+        $this->copyStubToApp('PanelProvider', $path, [
+            'class' => $class,
+            'directory' => str($id)->studly(),
+            'id' => $id,
+            'namespace' => $moduleNamespace,
+        ]);
+
+        $this->components->info("Successfully created {$class}!");
+
+        return static::SUCCESS;
+    }
+}

--- a/src/FilamentModularV3ServiceProvider.php
+++ b/src/FilamentModularV3ServiceProvider.php
@@ -7,6 +7,10 @@ use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Str;
 use Livewire\Features\SupportTesting\Testable;
 use Nwidart\Modules\Laravel\Module;
+use RealMrHex\FilamentModularV3\Commands\MakeModularPageCommand;
+use RealMrHex\FilamentModularV3\Commands\MakeModularRelationManagerCommand;
+use RealMrHex\FilamentModularV3\Commands\MakeModularResourceCommand;
+use RealMrHex\FilamentModularV3\Commands\MakePanelCommand;
 use RealMrHex\FilamentModularV3\Testing\TestsFilamentModularV3;
 use ReflectionException;
 use Spatie\LaravelPackageTools\Commands\InstallCommand;
@@ -19,10 +23,6 @@ class FilamentModularV3ServiceProvider extends PackageServiceProvider
 
     /**
      * Configure the package
-     *
-     * @param Package $package
-     *
-     * @return void
      */
     public function configurePackage(Package $package): void
     {
@@ -32,79 +32,67 @@ class FilamentModularV3ServiceProvider extends PackageServiceProvider
          * More info: https://github.com/spatie/laravel-package-tools
          */
         $package->name(static::$name)
-                ->hasCommands($this->getCommands())
-                ->hasInstallCommand(
-                    function (InstallCommand $command)
-                    {
-                        $command->askToStarRepoOnGitHub('realmrhex/filament-modular-v3');
-                    }
-                )
-        ;
+            ->hasCommands($this->getCommands())
+            ->hasInstallCommand(
+                function (InstallCommand $command) {
+                    $command->askToStarRepoOnGitHub('realmrhex/filament-modular-v3');
+                }
+            );
 
-        if (file_exists($package->basePath("/../config/{$package->shortName()}.php")))
+        if (file_exists($package->basePath("/../config/{$package->shortName()}.php"))) {
             $package->hasConfigFile();
+        }
     }
 
     /**
      * Handle package registration
-     *
-     * @return void
      */
     public function packageRegistered(): void
     {
-        $this->app->beforeResolving('filament', fn() => $this->addModularFunctionality());
+        $this->app->beforeResolving('filament', fn () => $this->addModularFunctionality());
         $this->registerModuleDiscoveryMacros();
     }
 
     /**
      * Add modular functionality to Filament
-     *
-     * @return void
      */
     private function addModularFunctionality(): void
     {
         $modules = $this->app['modules']->allEnabled();
 
-        foreach ($modules as $module)
-        {
+        foreach ($modules as $module) {
             $this->discoverPanels($module);
         }
     }
 
     /**
      * Discover Filament Panels
-     *
-     * @param Module $module
-     *
-     * @return void
      */
     private function discoverPanels(Module $module): void
     {
-        $providersDir = "{$module->getPath()}/Filament/Panels";
+        $providersDir = "{$module->getPath()}/Providers/Filament/Panels";
 
-        if (!is_dir($providersDir))
+        if (! is_dir($providersDir)) {
             return;
+        }
 
         $providers = scandir($providersDir);
 
-        foreach ($providers as $provider)
-        {
-            if (!preg_match('/^(.+)\.php$/', $provider, $matches))
-            {
+        foreach ($providers as $provider) {
+            if (! preg_match('/^(.+)\.php$/', $provider, $matches)) {
                 continue;
             }
 
-            $providerClass = "Modules\\{$module->getStudlyName()}\\Filament\\Panels\\{$matches[1]}";
+            $providerClass = "Modules\\{$module->getStudlyName()}\\Providers\\Filament\\Panels\\{$matches[1]}";
 
-            if (class_exists($providerClass))
+            if (class_exists($providerClass)) {
                 $this->app->register($providerClass);
+            }
         }
     }
 
     /**
      * Register modules discovery macros
-     *
-     * @return void
      */
     private function registerModuleDiscoveryMacros(): void
     {
@@ -115,37 +103,35 @@ class FilamentModularV3ServiceProvider extends PackageServiceProvider
 
     /**
      * Discover resources macro
-     *
-     * @return void
      */
     private function discoverResourcesMacro(): void
     {
         Panel::macro(
             'discoverModulesResources',
-            function ()
-            {
+            function () {
                 $resourcesList = [];
                 $modules = app()['modules']->allEnabled();
                 $panelId = Str::of($this->getId())->studly();
 
-                foreach ($modules as $module)
-                {
+                foreach ($modules as $module) {
                     $filamentDir = "{$module->getPath()}/Filament/$panelId/Resources";
 
-                    if (!is_dir($filamentDir))
+                    if (! is_dir($filamentDir)) {
                         continue;
+                    }
 
                     $resources = scandir($filamentDir);
 
-                    foreach ($resources as $resource)
-                    {
-                        if (!preg_match('/^(.+)\.php$/', $resource, $matches))
+                    foreach ($resources as $resource) {
+                        if (! preg_match('/^(.+)\.php$/', $resource, $matches)) {
                             continue;
+                        }
 
                         $resourceClass = "Modules\\{$module->getStudlyName()}\\Filament\\$panelId\\Resources\\$matches[1]";
 
-                        if (class_exists($resourceClass))
+                        if (class_exists($resourceClass)) {
                             $resourcesList[] = $resourceClass;
+                        }
                     }
                 }
 
@@ -161,39 +147,33 @@ class FilamentModularV3ServiceProvider extends PackageServiceProvider
 
     /**
      * Discover pages macro
-     *
-     * @return void
      */
     private function discoverPagesMacro(): void
     {
         Panel::macro(
             'discoverModulesPages',
-            function ()
-            {
+            function () {
                 $pagesList = [];
                 $modules = app()['modules']->allEnabled();
                 $panelId = Str::of($this->getId())->studly();
 
-                foreach ($modules as $module)
-                {
+                foreach ($modules as $module) {
                     $filamentDir = "{$module->getPath()}/Filament/$panelId/Pages";
 
-                    if (!is_dir($filamentDir))
-                    {
+                    if (! is_dir($filamentDir)) {
                         continue;
                     }
 
                     $pages = scandir($filamentDir);
 
-                    foreach ($pages as $page)
-                    {
-                        if (!preg_match('/^(.+)\.php$/', $page, $matches))
+                    foreach ($pages as $page) {
+                        if (! preg_match('/^(.+)\.php$/', $page, $matches)) {
                             continue;
+                        }
 
                         $pageClass = "Modules\\{$module->getStudlyName()}\\Filament\\$panelId\\Pages\\$matches[1]";
 
-                        if (class_exists($pageClass))
-                        {
+                        if (class_exists($pageClass)) {
                             $pagesList[] = $pageClass;
                         }
                     }
@@ -204,8 +184,7 @@ class FilamentModularV3ServiceProvider extends PackageServiceProvider
                     ...$pagesList,
                 ];
 
-                foreach ($pagesList as $page)
-                {
+                foreach ($pagesList as $page) {
                     $this->queueLivewireComponentForRegistration($page);
                 }
 
@@ -216,38 +195,30 @@ class FilamentModularV3ServiceProvider extends PackageServiceProvider
 
     /**
      * Discover widgets macro
-     *
-     * @return void
      */
     private function discoverWidgetsMacro(): void
     {
         Panel::macro(
             'discoverModulesWidgets',
-            function ()
-            {
+            function () {
                 $widgetsList = [];
                 $modules = app()['modules']->allEnabled();
                 $panelId = Str::of($this->getId())->studly();
 
-                foreach ($modules as $module)
-                {
+                foreach ($modules as $module) {
                     $widgetsDir = "{$module->getPath()}/Filament/$panelId/Widgets";
 
-                    if (is_dir($widgetsDir))
-                    {
+                    if (is_dir($widgetsDir)) {
                         $widgets = scandir($widgetsDir);
 
-                        foreach ($widgets as $widget)
-                        {
-                            if (!preg_match('/^(.+)\.php$/', $widget, $matches))
-                            {
+                        foreach ($widgets as $widget) {
+                            if (! preg_match('/^(.+)\.php$/', $widget, $matches)) {
                                 continue;
                             }
 
                             $widgetClass = "Modules\\{$module->getStudlyName()}\\Filament\\$panelId\\Widgets\\$matches[1]";
 
-                            if (class_exists($widgetClass))
-                            {
+                            if (class_exists($widgetClass)) {
                                 $widgetsList[] = $widgetClass;
                             }
                         }
@@ -255,30 +226,30 @@ class FilamentModularV3ServiceProvider extends PackageServiceProvider
 
                     $filamentDir = "{$module->getPath()}/Filament/$panelId/Resources";
 
-                    if (!is_dir($filamentDir))
-                    {
+                    if (! is_dir($filamentDir)) {
                         continue;
                     }
 
                     $resources = scandir($filamentDir);
                     unset($resources[0], $resources[1]);
 
-                    foreach ($resources as $resource)
-                    {
-                        if (!is_dir("$filamentDir/$resource") || !is_dir("$filamentDir/$resource/Widgets"))
+                    foreach ($resources as $resource) {
+                        if (! is_dir("$filamentDir/$resource") || ! is_dir("$filamentDir/$resource/Widgets")) {
                             continue;
+                        }
 
                         $widgets = scandir("$filamentDir/$resource/Widgets");
 
-                        foreach ($widgets as $widget)
-                        {
-                            if (!preg_match('/^(.+)\.php$/', $widget, $matches))
+                        foreach ($widgets as $widget) {
+                            if (! preg_match('/^(.+)\.php$/', $widget, $matches)) {
                                 continue;
+                            }
 
                             $widgetClass = "Modules\\{$module->getStudlyName()}\\Filament\\$panelId\\Resources\\$resource\\Widgets\\$matches[1]";
 
-                            if (class_exists($widgetClass))
+                            if (class_exists($widgetClass)) {
                                 $widgetsList[] = $widgetClass;
+                            }
                         }
                     }
                 }
@@ -288,8 +259,9 @@ class FilamentModularV3ServiceProvider extends PackageServiceProvider
                     ...$widgetsList,
                 ];
 
-                foreach ($widgetsList as $widget)
+                foreach ($widgetsList as $widget) {
                     $this->queueLivewireComponentForRegistration($this->normalizeWidgetClass($widget));
+                }
 
                 return $this;
             }
@@ -304,10 +276,8 @@ class FilamentModularV3ServiceProvider extends PackageServiceProvider
     public function packageBooted(): void
     {
         // Handle Stubs
-        if (app()->runningInConsole())
-        {
-            foreach (app(Filesystem::class)->files(__DIR__ . '/../stubs/') as $file)
-            {
+        if (app()->runningInConsole()) {
+            foreach (app(Filesystem::class)->files(__DIR__.'/../stubs/') as $file) {
                 $this->publishes(
                     [
                         $file->getRealPath() => base_path("stubs/filament-modular-v3/{$file->getFilename()}"),
@@ -321,12 +291,33 @@ class FilamentModularV3ServiceProvider extends PackageServiceProvider
         Testable::mixin(new TestsFilamentModularV3());
     }
 
-
     /**
      * @return array<class-string>
      */
     protected function getCommands(): array
     {
-        return [];
+        $commands = [
+            MakeModularPageCommand::class,
+            MakeModularRelationManagerCommand::class,
+            MakeModularResourceCommand::class,
+            MakePanelCommand::class,
+        ];
+
+        $aliases = [];
+
+        foreach ($commands as $command) {
+            $class = 'RealMrHex\\Commands\\Aliases\\'.class_basename($command);
+
+            if (! class_exists($class)) {
+                continue;
+            }
+
+            $aliases[] = $class;
+        }
+
+        return [
+            ...$commands,
+            ...$aliases,
+        ];
     }
 }

--- a/stubs/CustomResourcePage.stub
+++ b/stubs/CustomResourcePage.stub
@@ -1,0 +1,13 @@
+<?php
+
+namespace {{ namespace }};
+
+use {{ resource }};
+use {{ baseResourcePage }};
+
+class {{ resourcePageClass }} extends {{ baseResourcePageClass }}
+{
+    protected static string $resource = {{ resourceClass }}::class;
+
+    protected static string $view = '{{ view }}';
+}

--- a/stubs/Page.stub
+++ b/stubs/Page.stub
@@ -1,0 +1,12 @@
+<?php
+
+namespace {{ namespace }};
+
+use Filament\Pages\Page;
+
+class {{ class }} extends Page
+{
+    protected static ?string $navigationIcon = 'heroicon-o-document-text';
+
+    protected static string $view = '{{ view }}';
+}

--- a/stubs/PageView.stub
+++ b/stubs/PageView.stub
@@ -1,0 +1,3 @@
+<x-filament-panels::page>
+
+</x-filament-panels::page>

--- a/stubs/PanelProvider.stub
+++ b/stubs/PanelProvider.stub
@@ -1,0 +1,56 @@
+<?php
+
+namespace {{ namespace }};
+
+use Filament\Http\Middleware\Authenticate;
+use Filament\Http\Middleware\DisableBladeIconComponents;
+use Filament\Http\Middleware\DispatchServingFilamentEvent;
+use Filament\Pages;
+use Filament\Panel;
+use Filament\PanelProvider;
+use Filament\Support\Colors\Color;
+use Filament\Widgets;
+use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
+use Illuminate\Cookie\Middleware\EncryptCookies;
+use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken;
+use Illuminate\Routing\Middleware\SubstituteBindings;
+use Illuminate\Session\Middleware\AuthenticateSession;
+use Illuminate\Session\Middleware\StartSession;
+use Illuminate\View\Middleware\ShareErrorsFromSession;
+
+class {{ class }} extends PanelProvider
+{
+    public function panel(Panel $panel): Panel
+    {
+        return $panel
+            ->id('{{ id }}')
+            ->path('{{ id }}')
+            ->colors([
+                'primary' => Color::Amber,
+            ])
+            ->discoverResources(in: app_path('Filament/{{ directory }}/Resources'), for: 'App\\Filament\\{{ directory }}\\Resources')
+            ->discoverPages(in: app_path('Filament/{{ directory }}/Pages'), for: 'App\\Filament\\{{ directory }}\\Pages')
+            ->pages([
+                Pages\Dashboard::class,
+            ])
+            ->discoverWidgets(in: app_path('Filament/{{ directory }}/Widgets'), for: 'App\\Filament\\{{ directory }}\\Widgets')
+            ->widgets([
+                Widgets\AccountWidget::class,
+                Widgets\FilamentInfoWidget::class,
+            ])
+            ->middleware([
+                EncryptCookies::class,
+                AddQueuedCookiesToResponse::class,
+                StartSession::class,
+                AuthenticateSession::class,
+                ShareErrorsFromSession::class,
+                VerifyCsrfToken::class,
+                SubstituteBindings::class,
+                DisableBladeIconComponents::class,
+                DispatchServingFilamentEvent::class,
+            ])
+            ->authMiddleware([
+                Authenticate::class,
+            ]);
+    }
+}

--- a/stubs/RelationManager.stub
+++ b/stubs/RelationManager.stub
@@ -1,0 +1,52 @@
+<?php
+
+namespace {{ namespace }};
+
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\SoftDeletingScope;
+
+class {{ managerClass }} extends RelationManager
+{
+    protected static string $relationship = '{{ relationship }}';
+
+    public function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Forms\Components\TextInput::make('{{ recordTitleAttribute }}')
+                    ->required()
+                    ->maxLength(255),
+            ]);
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->recordTitleAttribute('{{ recordTitleAttribute }}')
+            ->columns([
+                Tables\Columns\TextColumn::make('{{ recordTitleAttribute }}'),
+            ])
+            ->filters([
+{{ tableFilters }}
+            ])
+            ->headerActions([
+{{ tableHeaderActions }}
+            ])
+            ->actions([
+{{ tableActions }}
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkActionGroup::make([
+{{ tableBulkActions }}
+                ]),
+            ])
+            ->emptyStateActions([
+{{ tableEmptyStateActions }}
+            ]){{ modifyQueryUsing }};
+    }
+}

--- a/stubs/Resource.stub
+++ b/stubs/Resource.stub
@@ -1,0 +1,58 @@
+<?php
+
+namespace {{ namespace }};
+
+use {{ resource }}\Pages;
+use {{ resource }}\RelationManagers;
+use App\Models\{{ model }};
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\SoftDeletingScope;
+
+class {{ resourceClass }} extends Resource
+{
+    protected static ?string $model = {{ modelClass }}::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-rectangle-stack';
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+{{ formSchema }}
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+{{ tableColumns }}
+            ])
+            ->filters([
+{{ tableFilters }}
+            ])
+            ->actions([
+{{ tableActions }}
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkActionGroup::make([
+{{ tableBulkActions }}
+                ]),
+            ])
+            ->emptyStateActions([
+{{ tableEmptyStateActions }}
+            ]);
+    }
+{{ relations }}
+    public static function getPages(): array
+    {
+        return [
+{{ pages }}
+        ];
+    }{{ eloquentQuery }}
+}

--- a/stubs/ResourceEditPage.stub
+++ b/stubs/ResourceEditPage.stub
@@ -1,0 +1,19 @@
+<?php
+
+namespace {{ namespace }};
+
+use {{ resource }};
+use Filament\Actions;
+use Filament\Resources\Pages\EditRecord;
+
+class {{ resourcePageClass }} extends EditRecord
+{
+    protected static string $resource = {{ resourceClass }}::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+{{ actions }}
+        ];
+    }
+}

--- a/stubs/ResourceListPage.stub
+++ b/stubs/ResourceListPage.stub
@@ -1,0 +1,19 @@
+<?php
+
+namespace {{ namespace }};
+
+use {{ resource }};
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class {{ resourcePageClass }} extends ListRecords
+{
+    protected static string $resource = {{ resourceClass }}::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/stubs/ResourceManagePage.stub
+++ b/stubs/ResourceManagePage.stub
@@ -1,0 +1,19 @@
+<?php
+
+namespace {{ namespace }};
+
+use {{ resource }};
+use Filament\Actions;
+use Filament\Resources\Pages\ManageRecords;
+
+class {{ resourcePageClass }} extends ManageRecords
+{
+    protected static string $resource = {{ resourceClass }}::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/stubs/ResourcePage.stub
+++ b/stubs/ResourcePage.stub
@@ -1,0 +1,12 @@
+<?php
+
+namespace {{ namespace }};
+
+use {{ resource }};
+use Filament\Actions;
+use {{ baseResourcePage }};
+
+class {{ resourcePageClass }} extends {{ baseResourcePageClass }}
+{
+    protected static string $resource = {{ resourceClass }}::class;
+}

--- a/stubs/ResourceViewPage.stub
+++ b/stubs/ResourceViewPage.stub
@@ -1,0 +1,19 @@
+<?php
+
+namespace {{ namespace }};
+
+use {{ resource }};
+use Filament\Actions;
+use Filament\Resources\Pages\ViewRecord;
+
+class {{ resourcePageClass }} extends ViewRecord
+{
+    protected static string $resource = {{ resourceClass }}::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\EditAction::make(),
+        ];
+    }
+}

--- a/stubs/ThemeCss.stub
+++ b/stubs/ThemeCss.stub
@@ -1,0 +1,3 @@
+@import '../../../../vendor/filament/filament/resources/css/theme.css';
+
+@config './tailwind.config.js';

--- a/stubs/ThemePostcssConfig.stub
+++ b/stubs/ThemePostcssConfig.stub
@@ -1,0 +1,6 @@
+export default {
+    plugins: {
+        tailwindcss: {},
+        autoprefixer: {},
+    },
+}

--- a/stubs/ThemeTailwindConfig.stub
+++ b/stubs/ThemeTailwindConfig.stub
@@ -1,0 +1,10 @@
+import preset from '../../../../vendor/filament/filament/tailwind.config.preset'
+
+export default {
+    presets: [preset],
+    content: [
+        './app/Filament/{{ classPathPrefix }}**/*.php',
+        './resources/views/filament/{{ viewPathPrefix }}**/*.blade.php',
+        './vendor/filament/**/*.blade.php',
+    ],
+}


### PR DESCRIPTION
In this pull request, I've added several Filament commands to enhance the modularity of our Laravel application when using the nwidart/laravel-modules package. The new commands facilitate the creation and management of modular pages, relation managers, resources, and panels within Filament.

- `MakeModularPageCommand::class`: Creates a new modular page.
- `MakeModularRelationManagerCommand::class`: Generates a new modular relation manager.
- `MakeModularResourceCommand::class`: Adds a new modular resource.
- `MakePanelCommand::class`: Creates a new panel for Filament.